### PR TITLE
Add CodeQL analysis workflow (2025-07-31T19-30-37)

### DIFF
--- a/.github/workflows/codeql-analysis-2025-07-31T19-30-37.yml
+++ b/.github/workflows/codeql-analysis-2025-07-31T19-30-37.yml
@@ -1,0 +1,52 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master", "main" ]
+  schedule:
+    - cron: "36 18 * * 0"
+
+permissions:
+  actions: read         # for actions/checkout to fetch code
+  contents: read        # to fetch code (if private)
+  security-events: write  # to upload SARIF results to GitHub
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+        continue-on-error: true
+
+      - name: Manual Maven Build
+        run: mvn install -DskipTests
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"
+
+      - name: Scan workflow files
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: .github/workflows


### PR DESCRIPTION
This pull request adds the auto-generated CodeQL workflow for Java using Maven to scan source and workflow files. The workflow triggers on push, pull_request, and weekly schedules. Merging this PR will enable automatic security scanning by GitHub CodeQL.