### PR TITLE
Add CI pipeline to nexops-pipeline_20250808_100426

### DIFF
--- a/.github/workflows/pipeline_20250808_100426
+++ b/.github/workflows/pipeline_20250808_100426
@@ -1,0 +1,43 @@
+name: CI - Java Spring MVC Maven
+
+on:
+  push:
+    branches: [nexops-pipeline_20250808_100426]
+  pull_request:
+    branches: [master, nexops-pipeline_20250808_100426]
+  workflow_dispatch:
+
+jobs:
+  build-test-analyze:
+    runs-on: ubuntu-latest
+    name: Build, Test, Analyze, Publish Artifact
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Build and test (Maven)
+        run: mvn -B clean verify
+
+      - name: SonarQube Scan
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: |
+          mvn -B sonar:sonar \
+            -Dsonar.projectKey=$(grep -m1 '^sonar.projectKey=' sonar-project.properties | cut -d'=' -f2) \
+            -Dsonar.host.url="$SONAR_HOST_URL" \
+            -Dsonar.login="$SONAR_TOKEN"
+        if: ${{ (env.SONAR_TOKEN && env.SONAR_HOST_URL) || (secrets.SONAR_TOKEN && secrets.SONAR_HOST_URL) }}
+
+      - name: Publish build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spring-mvc-artifact
+          path: target/*.jar


### PR DESCRIPTION
This PR adds a new CI pipeline configuration to branch nexops-pipeline_20250808_100426. The workflow enables build, test, SonarQube analysis, and artifact publishing for Java Spring MVC (Maven). Please review and merge.